### PR TITLE
[MOBILE] [IOS] Se le permite al usuario saltearse las validaciones.

### DIFF
--- a/components/Touchable.tsx
+++ b/components/Touchable.tsx
@@ -5,7 +5,7 @@ import { RectButton } from 'react-native-gesture-handler';
 // Workaround for RectButton not working inside the bottom sheet
 export default function Touchable({ children, ...props }) {
   if (Platform.OS === 'ios') {
-    return <TouchableOpacity {...props}>{children}</TouchableOpacity>;
+    return <TouchableOpacity {...props} disabled={(props.enabled === undefined) ? false : !props.enabled}>{children}</TouchableOpacity>;
   }
   return <RectButton {...props}>{children}</RectButton>;
 }


### PR DESCRIPTION
El componente TouchableOpacity para desactivarse requiere que se le pase por props **"disabled = true"** en el caso de la app se utiliza **enabled** lo cual permite al usuario saltearse esta validación dado que en iOS queda sin efecto.